### PR TITLE
COR-342: DateTime Field is Not Nullable Bugfix

### DIFF
--- a/app/models/date_time_field_type.rb
+++ b/app/models/date_time_field_type.rb
@@ -7,7 +7,7 @@ class DateTimeFieldType < FieldType
   attr_reader :validations, :metadata
 
   validates :timestamp, presence: true, if: :validate_presence?
-  validate :timestamp_is_allowed?
+  validate :timestamp_is_valid?
 
   def validations=(validations_hash)
     @validations = validations_hash.deep_symbolize_keys
@@ -41,7 +41,7 @@ class DateTimeFieldType < FieldType
     "#{field_name.parameterize('_')}_date_time"
   end
 
-  def timestamp_is_allowed?
+  def timestamp_is_valid?
     if @timestamp.nil?
       true
     else

--- a/app/models/date_time_field_type.rb
+++ b/app/models/date_time_field_type.rb
@@ -42,12 +42,16 @@ class DateTimeFieldType < FieldType
   end
 
   def timestamp_is_allowed?
-    begin
-      DateTime.parse(@timestamp)
+    if @timestamp.nil?
       true
-    rescue ArgumentError
-      errors.add(:timestamp, 'must be a valid date')
-      false
+    else
+      begin
+        DateTime.parse(@timestamp)
+        true
+      rescue ArgumentError
+        errors.add(:timestamp, 'must be a valid date')
+        false
+      end
     end
   end
 


### PR DESCRIPTION
- Updated `#timestamp_is_allowed?` with `nil` check 
  - Will now allow for empty `DateTime` fields
  - `DateTime` presence validation is optional
- Changed method name to `#timestamp_is_valid?`

@toastercup @ElliottAYoung 
