### PR TITLE
AssetFieldType Implementation

### DIFF
--- a/app/cells/field_types/core/asset/input.haml
+++ b/app/cells/field_types/core/asset/input.haml
@@ -1,0 +1,3 @@
+= render_field_id
+= render_label
+= render_input

--- a/app/cells/field_types/core/asset_cell.rb
+++ b/app/cells/field_types/core/asset_cell.rb
@@ -1,0 +1,19 @@
+module FieldTypes
+  module Core
+    class AssetCell < FieldTypes::Core::Cell
+      def input
+        render
+      end
+
+      private
+
+      def render_label
+        @options[:form].label 'data[asset]', field.name
+      end
+
+      def render_input
+        @options[:form].file_field 'data[asset]'
+      end
+    end
+  end
+end

--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -1,0 +1,84 @@
+class AssetFieldType < FieldType
+  VALIDATION_TYPES = {
+    presence: :valid_presence_validation?,
+    size: :valid_size_validation?,
+    content_type: :valid_content_type_validation?
+  }.freeze
+
+  attr_accessor :asset_file_name,
+                :asset_content_type,
+                :asset_file_size,
+                :asset_updated_at,
+                :field_name
+
+  attr_reader :data, :validations
+
+  has_attached_file :asset
+  do_not_validate_attachment_file_type :asset
+
+  validates :asset, attachment_presence: true, if: :validate_presence?
+
+  def validations=(validations_hash)
+    @validations = validations_hash.deep_symbolize_keys
+  end
+
+  def data=(data_hash)
+    self.asset = data_hash.deep_symbolize_keys[:asset]
+  end
+
+  def acceptable_validations?
+    valid_types? && valid_options?
+  end
+
+  def field_item_as_indexed_json_for_field_type(field_item, options = {})
+    json = {}
+    json[mapping_field_name] = asset_file_name
+    json
+  end
+
+  def mapping
+    {name: mapping_field_name, type: :string, analyzer: :keyword}
+  end
+
+  private
+
+  def mapping_field_name
+    "#{field_name.parameterize('_')}_asset_file_name"
+  end
+
+  def valid_types?
+    validations.all? do |type, options|
+      VALIDATION_TYPES.include?(type.to_sym)
+    end
+  end
+
+  def valid_options?
+    validations.all? do |type, options|
+      self.send(VALIDATION_TYPES[type])
+    end
+  end
+
+  def validate_presence?
+    @validations.key? :presence
+  end
+
+  alias_method :valid_presence_validation?, :validate_presence?
+
+  def valid_size_validation?
+    begin
+      AttachmentSizeValidator.new(validations[:size].merge(attributes: :asset))
+      true
+    rescue ArgumentError, NoMethodError
+      false
+    end
+  end
+
+  def valid_content_type_validation?
+    begin
+      AttachmentContentTypeValidator.new(validations[:content_type].merge(attributes: :asset))
+      true
+    rescue ArgumentError, NoMethodError
+      false
+    end
+  end
+end

--- a/lib/cortex/field_types/core/version.rb
+++ b/lib/cortex/field_types/core/version.rb
@@ -1,7 +1,7 @@
 module Cortex
   module FieldTypes
     module Core
-      VERSION = '0.1.1'
+      VERSION = '0.2.0'
     end
   end
 end


### PR DESCRIPTION
This PR represents the beginnings of the `AssetFieldType`, which will allow content creators to upload files as part of a `ContentType`. This current implementation does not yet feature a fully-functioning storage mechanism for the Paperclip data. Instead, it includes some prototype code (`AssetFieldType`) from a consultant. As part of this PR, refactorings have begun to get this functioning.
- Includes new `AssetCell`
- Migrates `AssetFieldType` from Cortex
- Refactorings begun for `AssetFieldType`
- Bumps major version to `v0.2.0`. New `AssetCell` requires form encoding to be multipart, which is a breaking change
