### PR TITLE
COR-342: DateTime Presence Validation Bug

### DIFF
--- a/app/models/date_time_field_type.rb
+++ b/app/models/date_time_field_type.rb
@@ -42,7 +42,7 @@ class DateTimeFieldType < FieldType
   end
 
   def timestamp_is_valid?
-    if @timestamp.nil?
+    if @timestamp.blank? || @timestamp.nil?
       true
     else
       begin

--- a/app/models/date_time_field_type.rb
+++ b/app/models/date_time_field_type.rb
@@ -42,7 +42,7 @@ class DateTimeFieldType < FieldType
   end
 
   def timestamp_is_valid?
-    if @timestamp.blank? || @timestamp.nil?
+    if @timestamp.blank?
       true
     else
       begin


### PR DESCRIPTION
@toastercup @arelia @MKwenhua 

It looks like an empty timestamp is being passed along as "", which would not fail a check for `nil?`. Changes the conditional before the validation to check for either an empty String or a nil object, both of which would cause a false validation failure.
