### PR TITLE
Multiline Text

### DIFF
--- a/app/cells/plugins/core/text/input.haml
+++ b/app/cells/plugins/core/text/input.haml
@@ -2,3 +2,4 @@
   = render_field_id
   = render_label
   = render_input
+  

--- a/app/cells/plugins/core/text/multiline_input.haml
+++ b/app/cells/plugins/core/text/multiline_input.haml
@@ -1,3 +1,4 @@
-= render_label
-= render_field_id
-= render_multiline_input
+.mdl-textfield.mdl-js-textfield
+  = render_label
+  = render_field_id
+  = render_multiline_input

--- a/app/cells/plugins/core/text_cell.rb
+++ b/app/cells/plugins/core/text_cell.rb
@@ -15,14 +15,18 @@ module Plugins
 
       private
 
+      def input_display
+        @options[:input_options]&.[](:display)
+      end
+
       def input_classes
-        @options[:input_options]&.[](:display)&.[](:classes)
+        input_display&.[](:classes)
       end
 
       def input_styles
-        @options[:input_options]&.[](:display)&.[](:styles)
+        input_display&.[](:styles)
       end
-
+      
       def value
         data&.[]('text') || @options[:default_value]
       end
@@ -46,7 +50,7 @@ module Plugins
       end
 
       def render_multiline_input
-        @options[:form].text_area_tag 'data[text]', value: value # , cols: @options[:cols], rows: @options[:rows]
+        @options[:form].text_area 'data[text]', value: value , placeholder: @options[:placeholder], rows: input_display&.[](:rows) , class: 'mdl-textfield__input'
       end
     end
   end

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -54,7 +54,11 @@ namespace :cortex do
                       "id": media.fields[1].id
                     },
                     {
-                      "id": media.fields[2].id
+                      "id": media.fields[2].id,
+                      "render_method": "multiline_input",
+                      "display": {
+                         "rows": 3
+                      }
                     },
                     {
                       "id": media.fields[3].id


### PR DESCRIPTION
This PR provides a working multiline_input method in  `TextCell < Plugins::Core::Cell`  changes include: 
- Renders textarea tag with dynamic row sizing
- `input_display` method for all html attributes nested in display key in the wizard
- in media.rake I added `"render_method": "multiline_input"`  and a rows attribute in  #display.
