### PR TITLE
COR-224: Edit Existing Assets

### DIFF
--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -20,6 +20,7 @@ class AssetFieldType < FieldType
   end
 
   def data=(data_hash)
+    @existing_data = data_hash.deep_symbolize_keys[:existing_data]
     self.asset = data_hash.deep_symbolize_keys[:asset]
   end
 
@@ -27,7 +28,7 @@ class AssetFieldType < FieldType
     {
         'asset': {
             'file_name': asset_file_name,
-            'url': asset.url,
+            'url': url,
             'dimensions': dimensions,
             'content_type': asset_content_type,
             'file_size': asset_file_size,
@@ -112,5 +113,9 @@ class AssetFieldType < FieldType
 
   def validate_asset_content_type
     attachment_content_type_validator.validate_each(self, :asset, asset)
+  end
+
+  def url
+    @existing_data.empty? ?  asset.url : @existing_data[:asset][:url]
   end
 end


### PR DESCRIPTION
@toastercup @arelia @MKwenhua 

Gives us the @existing_data instance variable from previously held data passed in PR [#367](https://github.com/cbdr/cortex/pull/367) - previously we would update the URL each time based on the current AssetFieldType, which was new'd on every update thus creating a new id and a different URL. This still has the same newing of the AssetFieldType, but will track the previous id to keep it consistent between updates.

Our S3 buckets have been prepped with the S3 versioning so once this goes up instead of overwriting the file it will create a new version of that file. Any time the file is accessed without a version_id it defaults to the newest one.
