### PR TITLE
Media Seeder Decorator Fixes

### DIFF
--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -59,7 +59,7 @@ namespace :cortex do
               "columns": [
                 {
                   "grid_width": 12,
-                  "fields": [
+                  "elements": [
                     {
                       "id": media.fields[0].id
                     }
@@ -74,7 +74,7 @@ namespace :cortex do
               "columns": [
                 {
                   "grid_width": 12,
-                  "fields": [
+                  "elements": [
                     {
                       "id": media.fields[1].id
                     },


### PR DESCRIPTION
Utilize new `elements` object spec in `Media`/`Decorator` seeder task
