### PR TITLE
COR-224: Massage and Pass Metadata in AssetFieldType for Consistent Assets

### DIFF
--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -130,6 +130,6 @@ class AssetFieldType < FieldType
     # that will be added later and we don't want to duplicate it
     # Then remove the old file extension and replace it with the paperclipp'd new one
     new_path = URI.parse(path).path.slice(1..-1)
-    new_path.gsub(/\.\w{2,6}$/, ".:extension")
+    new_path.gsub(File.extname(path), ".:extension")
   end
 end

--- a/lib/cortex/plugins/core/version.rb
+++ b/lib/cortex/plugins/core/version.rb
@@ -1,7 +1,7 @@
 module Cortex
   module Plugins
     module Core
-      VERSION = '0.4.4'
+      VERSION = '0.4.5'
     end
   end
 end


### PR DESCRIPTION
@toastercup @arelia @MKwenhua 

Handles the existing data to massage the metadata into a form that can be used to maintain consistent assets. Now, instead of the URL being generated each time, the url is determined from previous incarnations, with the extension being updated, allowing us to version assets on S3 (unless of course the extension changes between uploads, that would obviously be a new file 😛)
