### PR TITLE
COR-495: Add note about Categories max and min validation

### DIFF
--- a/app/cells/plugins/core/tree/checkboxes.haml
+++ b/app/cells/plugins/core/tree/checkboxes.haml
@@ -1,5 +1,8 @@
 %h4
   = render_label
+  
+%p
+  Please select 1-2 Categories.
 
 - @options[:metadata]["data"]["tree_array"].each do |node|
   = render_field_id


### PR DESCRIPTION
@toastercup @arelia @MKwenhua 

I know this seems trivial, but Justin just wants the Checkbox list to inform the User of how many choices they can make (which is this case is 1-2) so they're not taken by surprise when it fails on them.  This is something we should visit as a feature, but for now I've hardcoded it in so that it will be there for him to display to the end users soon