### PR TITLE
COR-569: Paperclip Non-Image Upload Bug Fix

### DIFF
--- a/app/cells/plugins/core/asset_info/index.haml
+++ b/app/cells/plugins/core/asset_info/index.haml
@@ -1,2 +1,2 @@
 - if asset
-  = image_tag(asset['style_urls'][config[:thumbnail_style]], height: '50px')
+  = image_tag(asset_thumb(asset), height: '50px')

--- a/app/cells/plugins/core/asset_info_cell.rb
+++ b/app/cells/plugins/core/asset_info_cell.rb
@@ -20,6 +20,10 @@ module Plugins
         @options[:config] || {}
       end
 
+      def asset_thumb(asset)
+        asset['style_urls'] ? asset['style_urls'][config[:thumbnail_style]] : 'https://secure.gravatar.com/avatar/f995c9cc06a8282138cf6c0691396f6d'
+      end
+
       def asset
         data['asset']
       end

--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -16,7 +16,7 @@ class AssetFieldType < FieldType
   validate :validate_asset_content_type, if: :validate_content_type?
 
   def metadata=(metadata_hash)
-    @metadata = metadata_hash.deep_symbolize_keys
+    @metadata = format_data(metadata_hash).deep_symbolize_keys
     @existing_data = metadata_hash[:existing_data]
     Paperclip::HasAttachedFile.define_on(self.class, :asset, existing_metadata)
   end
@@ -51,6 +51,15 @@ class AssetFieldType < FieldType
   end
 
   private
+
+  def is_image(mime_type)
+    ["image/jpeg", "image/pjpeg", "image/png","application/pdf" ,"image/x-png", "image/gif"].include?(mime_type)
+  end
+
+  def format_data(metadata_hash)
+   return metadata_hash if is_image(metadata_hash[:content_type])
+   metadata_hash.reject{|k| k == "processors"}
+  end
 
   def image?
     asset_content_type =~ %r{^(image|(x-)?application)/(bmp|gif|jpeg|jpg|pjpeg|png|x-png)$}


### PR DESCRIPTION
@toastercup @ElliottAYoung  @arelia This is not a final PR, but mostly for you all to review and look over. I will make the necessary changes as needed tomorrow base on everyone's input. 

But anyways I got paperclip to skip post processing on non image files by removing the `:thumbnail` post processor from the `AssetFileType`'s metadata in the `format_data` method. 

**Note**: This relies on [cortex/pull/408](https://github.com/cbdr/cortex/pull/408) in file [app/models/field_item.rb](https://github.com/cbdr/cortex/blob/80a48cc4b0c3af0747a5ca7f096304eedf1831e7/app/models/field_item.rb) to pass the assets `content_type` to work, which can be viewed in the method below:
```ruby
def asset_check(data_hash)
   data_hash["asset"] ? {existing_data: data, content_type:  data_hash["asset"].content_type} : {existing_data: data}
end
```