### PR TITLE
COR-574: Remove h4 Tag Around Categories Form Label

### DIFF
--- a/app/cells/plugins/core/tree/checkboxes.haml
+++ b/app/cells/plugins/core/tree/checkboxes.haml
@@ -1,6 +1,5 @@
-%h4
-  = render_label
-  
+= render_label
+
 %p
   Please select 1-2 Categories.
 


### PR DESCRIPTION
- Removed `<h4>` around Categories form label
  - I don't think the label is semantically an `h4` and being an `h4` made the Categories label smaller than the labels around it

![image](https://cloud.githubusercontent.com/assets/2359538/21368870/f3187b50-c6c9-11e6-8081-676d3ebfc916.png)
