### PR TITLE
Open Asset URLs In New Tab

### DIFF
--- a/app/cells/plugins/core/asset_info_cell.rb
+++ b/app/cells/plugins/core/asset_info_cell.rb
@@ -41,7 +41,7 @@ module Plugins
       end
 
       def link_to_asset
-        link_to(asset['url'], asset['url'])
+        link_to asset['url'], asset['url'], target: '_blank'
       end
     end
   end


### PR DESCRIPTION
@justin3thompson just mentioned how much he hates external URLs that open in the same window, and so do I. This PR attempts to take that to heart by ensuring `link_to_asset` in `asset_info_cell` opens Asset URLs in a new tab