### PR TITLE
COR-569: Support For Non-Image View Rendering & Paperclip Non-Image Upload bug fix

### DIFF
--- a/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
+++ b/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
@@ -7,14 +7,22 @@
       editor.widgets.add('media', {
         template: '<media><img></media>',
         data: function () {
-          if (this.data.id) {
-            var image_element = this.element.getFirst(),
-              alt_text = this.data.alt || this.data.title;
+          var image_element = this.element.getFirst(),
+            alt_text = this.data.alt || this.data.title,
+            width = this.data.width || this.element.getAttribute('width'),
+            height = this.data.height || this.element.getAttribute('height'),
+            style = this.data.style || this.element.getAttribute('style'),
+            className = this.data.class || this.element.getAttribute('class');
 
+          if (this.data.id) {
             this.element.setAttribute('id', this.data.id);
             image_element.setAttribute('src', this.data.image_source);
             image_element.setAttribute('alt', alt_text);
           }
+          if (width) image_element.setAttribute('width', width);
+          if (height) image_element.setAttribute('height', height);
+          if (style) image_element.setAttribute('style', style);
+          if (className) image_element.setAttribute('class', className);
         },
         requiredContent: 'media; img',
         upcast: function (element) {

--- a/app/cells/plugins/core/asset_cell.rb
+++ b/app/cells/plugins/core/asset_cell.rb
@@ -40,7 +40,7 @@ module Plugins
       end
 
       def associated_content_item_thumb_url
-        data['asset']['style_urls']['mini']
+        data['asset']['image'] ?  data['asset']['style_urls']['mini'] : 'https://s3.amazonaws.com/canvasmp3/cor_file_default.png'
       end
 
       def render_associated_content_item_thumb

--- a/app/cells/plugins/core/asset_info/index.haml
+++ b/app/cells/plugins/core/asset_info/index.haml
@@ -1,2 +1,4 @@
-- if asset
+- if asset['image']
   = image_tag(asset['style_urls'][config[:thumbnail_style]], height: '50px')
+- else
+  = image_tag('https://s3.amazonaws.com/canvasmp3/cor_file_default.png', height: '50px')

--- a/app/cells/plugins/core/asset_info/show.haml
+++ b/app/cells/plugins/core/asset_info/show.haml
@@ -7,7 +7,10 @@
   .asset-info.mdl-card.mdl-shadow--2dp
     .mdl-card__title
       %h2.mdl-card__title-text
-        = image_tag(asset['url'], style: 'max-height: 200px;')
+        - if asset['image']
+          = image_tag(asset['url'], style: 'max-height: 200px;')
+        - else
+          = asset['content_type']
     .mdl-card__supporting-text
       %dl
         %dt Original Filename
@@ -21,7 +24,7 @@
           = number_to_human_size(asset['file_size'])
         %dt Dimensions
         %dd
-          = dimensions
+          = asset['image'] ? dimensions : 'Not Image Asset'
         %dt Creator
         %dd
           = creator.fullname

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -17,7 +17,7 @@ namespace :cortex do
 
         puts "Creating Fields..."
 
-        allowed_asset_content_types = %w(txt css js pdf doc docx ppt pptx csv xls xlsx svg ico png jpg gif bmp)
+        allowed_asset_content_types = %w(txt css js pdf doc docx ppt pptx csv xls xlsx odt epub svg ico png jpg gif bmp)
         media.fields.new(name: 'Asset', field_type: 'asset_field_type',
                          validations:
                            {
@@ -29,15 +29,17 @@ namespace :cortex do
                            },
                          metadata:
                            {
-                             styles: {
-                               large: {geometry: '1800x1800>', format: :jpg},
-                               medium: {geometry: '800x800>', format: :jpg},
-                               default: {geometry: '300x300>', format: :jpg},
-                               mini: {geometry: '100x100>', format: :jpg},
-                               micro: {geometry: '50x50>', format: :jpg},
-                               post_tile: {geometry: '1140x', format: :jpg}
+                            image_styles: {
+                                styles: {
+                                  large: {geometry: '1800x1800>', format: :jpg},
+                                  medium: {geometry: '800x800>', format: :jpg},
+                                  default: {geometry: '300x300>', format: :jpg},
+                                  mini: {geometry: '100x100>', format: :jpg},
+                                  micro: {geometry: '50x50>', format: :jpg},
+                                  post_tile: {geometry: '1140x', format: :jpg}
+                                },
+                                processors: [:thumbnail, :paperclip_optimizer]
                              },
-                             processors: [:thumbnail, :paperclip_optimizer],
                              preserve_files: true,
                              path: ':class/:attachment/careerbuilder-:style-:id.:extension',
                              s3_headers: {'Cache-Control': 'public, max-age=315576000'}


### PR DESCRIPTION
**EDIT:**
I have decided that instead of removing the styles attribute, I just nested the data under _image_styles_:
```ruby 
metadata:
 {
  image_styles: {
      styles: {
        large: {geometry: '1800x1800>', format: :jpg},
        medium: {geometry: '800x800>', format: :jpg},
        default: {geometry: '300x300>', format: :jpg},
        mini: {geometry: '100x100>', format: :jpg},
        micro: {geometry: '50x50>', format: :jpg},
        post_tile: {geometry: '1140x', format: :jpg}
      },
      processors: [:thumbnail, :paperclip_optimizer]
   },
   preserve_files: true,
   path: ':class/:attachment/careerbuilder-:style-:id.:extension',
   s3_headers: {'Cache-Control': 'public, max-age=315576000'}
}
```
This allows users to still define styles without having Paperclip apply these styles to non-image assets. 

Additionally in [cortex pr#421](https://github.com/cbdr/cortex/pull/421) I pass in `ActionDispatch` data with all metadata under `:field_data`:
```ruby
  def format_data(metadata_hash)
   return metadata_hash unless is_image?(metadata_hash[:field_data]["asset"].content_type)
   metadata_hash.merge(metadata_hash["image_styles"])
  end
```


**--Outdated changes below---**

I removed `styles` and `processors` from `media.rake` and moved that code into a method as seen below: 
```ruby 
def image_asset_styles
  {
    styles: {
      large: {geometry: '1800x1800>', format: :jpg},
      medium: {geometry: '800x800>', format: :jpg},
      default: {geometry: '300x300>', format: :jpg},
      mini: {geometry: '100x100>', format: :jpg},
      micro: {geometry: '50x50>', format: :jpg},
      post_tile: {geometry: '1140x', format: :jpg}
    },
    processors: [:thumbnail, :paperclip_optimizer]
  }
end
```

which is used to merge into `@metadata` if the assets content_type is an image/pdf: 

```ruby
def format_data(metadata_hash)
  return metadata_hash unless is_image(metadata_hash[:content_type])
  metadata_hash.merge(image_asset_styles)
end
```

this relies on content_type being passed to `AssetFieldType` in cortex(which is a separate PR). 

Additionally I added `application/zip` to **allowed_asset_content_types**. Another small bug I had to fix was `asset_info` index and show were throwing errors expecting an asset thumbnail and reading dimensions . 