### PR TITLE
Blog Content Item Edit Bug Fix

### DIFF
--- a/app/cells/plugins/core/asset_info/index.haml
+++ b/app/cells/plugins/core/asset_info/index.haml
@@ -1,2 +1,2 @@
 - if asset
-  = image_tag(asset_thumb(asset), height: '50px')
+  = image_tag(asset['style_urls'][config[:thumbnail_style]], height: '50px')

--- a/app/cells/plugins/core/asset_info/index.haml
+++ b/app/cells/plugins/core/asset_info/index.haml
@@ -1,2 +1,2 @@
 - if asset
-  = image_tag(asset['style_urls'][config[:thumbnail_style]], height: '50px')
+  = image_tag(asset_thumb(asset), height: '50px')

--- a/app/cells/plugins/core/asset_info_cell.rb
+++ b/app/cells/plugins/core/asset_info_cell.rb
@@ -41,7 +41,7 @@ module Plugins
       end
 
       def link_to_asset
-        link_to(asset['url'], asset['url'])
+        link_to asset['url'], asset['url'], target: '_blank'
       end
     end
   end

--- a/app/cells/plugins/core/content_item/popup.haml
+++ b/app/cells/plugins/core/content_item/popup.haml
@@ -1,5 +1,5 @@
 = render_field_id
-= render_popup
+= render_content_item_id
 
 = render_label
 %br

--- a/app/cells/plugins/core/content_item/popup.haml
+++ b/app/cells/plugins/core/content_item/popup.haml
@@ -1,3 +1,5 @@
+= render_field_id
+= render_popup
 = render_label
 %br
 %button.content_item_button.text-center.popup--open

--- a/app/cells/plugins/core/content_item/popup.haml
+++ b/app/cells/plugins/core/content_item/popup.haml
@@ -1,5 +1,6 @@
 = render_field_id
 = render_popup
+
 = render_label
 %br
 %button.content_item_button.text-center.popup--open

--- a/app/cells/plugins/core/content_item_cell.rb
+++ b/app/cells/plugins/core/content_item_cell.rb
@@ -7,8 +7,16 @@ module Plugins
 
       private
 
+      def value
+        data&.[]('content_item_id')
+      end
+
       def render_label
         "Add #{field.name}"
+      end
+
+      def render_popup
+        @options[:form].text_field 'data[content_item_id]', value: value, style: 'display:none;'
       end
     end
   end

--- a/app/cells/plugins/core/content_item_cell.rb
+++ b/app/cells/plugins/core/content_item_cell.rb
@@ -15,8 +15,8 @@ module Plugins
         "Add #{field.name}"
       end
 
-      def render_popup
-        @options[:form].text_field 'data[content_item_id]', value: value, style: 'display:none;'
+      def render_content_item_id
+        @options[:form].hidden_field 'data[content_item_id]', value: value
       end
     end
   end

--- a/app/models/boolean_field_type.rb
+++ b/app/models/boolean_field_type.rb
@@ -7,7 +7,7 @@ class BooleanFieldType < FieldType
 
   def field_item_as_indexed_json_for_field_type(field_item, options = {})
     json = {}
-    json[mapping_field_name] = field_item.data['boolean']
+    json[mapping_field_name] = field_item.data['value']
     json
   end
 

--- a/app/models/content_item_field_type.rb
+++ b/app/models/content_item_field_type.rb
@@ -7,7 +7,7 @@ class ContentItemFieldType < FieldType
 
   def field_item_as_indexed_json_for_field_type(field_item, options = {})
     json = {}
-    json[mapping_field_name] = field_item.data['content_item']
+    json[mapping_field_name] = field_item.data['content_item_id']
     json
   end
 

--- a/app/models/content_item_field_type.rb
+++ b/app/models/content_item_field_type.rb
@@ -1,4 +1,16 @@
 class ContentItemFieldType < FieldType
+  attr_accessor :content_item_id
+
+  def data=(data_hash)
+    @content_item_id = data_hash.deep_symbolize_keys[:content_item_id]
+  end
+
+  def field_item_as_indexed_json_for_field_type(field_item, options = {})
+    json = {}
+    json[mapping_field_name] = field_item.data['content_item']
+    json
+  end
+
   def mapping
     { name: mapping_field_name, type: :string, analyzer: :snowball }
   end

--- a/app/models/date_time_field_type.rb
+++ b/app/models/date_time_field_type.rb
@@ -10,7 +10,7 @@ class DateTimeFieldType < FieldType
 
   def field_item_as_indexed_json_for_field_type(field_item, options = {})
     json = {}
-    json[mapping_field_name] = field_item.data['date_time']
+    json[mapping_field_name] = field_item.data['timestamp']
     json
   end
 

--- a/app/models/tag_field_type.rb
+++ b/app/models/tag_field_type.rb
@@ -10,7 +10,7 @@ class TagFieldType < FieldType
 
   def field_item_as_indexed_json_for_field_type(field_item, options = {})
     json = {}
-    json[mapping_field_name] = field_item.data['tag']
+    json[mapping_field_name] = field_item.data['tag_list']
     json
   end
 

--- a/app/models/tree_field_type.rb
+++ b/app/models/tree_field_type.rb
@@ -21,7 +21,7 @@ class TreeFieldType < FieldType
 
   def field_item_as_indexed_json_for_field_type(field_item, options = {})
     json = {}
-    json[mapping_field_name] = field_item.data['tree']
+    json[mapping_field_name] = field_item.data['values']
     json
   end
 

--- a/app/models/user_field_type.rb
+++ b/app/models/user_field_type.rb
@@ -10,7 +10,7 @@ class UserFieldType < FieldType
 
   def field_item_as_indexed_json_for_field_type(field_item, options = {})
     json = {}
-    json[mapping_field_name] = field_item.data['user']
+    json[mapping_field_name] = field_item.data['user_id']
     json
   end
 


### PR DESCRIPTION
The reason for the bug is in [content_item/popup.haml](https://github.com/cortex-cms/cortex-plugins-core/blob/develop/app/cells/plugins/core/content_item/popup.haml) no input was being rendered for the `content_item ` field, so when the Blog record is saved no **ContentItemFieldType** `FieldItem` record is created and saved in the database. So when the wizard decorator tries to render out the content item's existing fields there is no `field_item` for the content_item association. 

So how I fixed it was simply adding an actual input field, and add methods to support creating a record even if blank. 
