### PR TITLE
COR-525, COR-527: ContentItemFieldType Association And Selection Implementation

### DIFF
--- a/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
+++ b/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
@@ -1,4 +1,4 @@
-(function (global) { 
+(function (global) {
   'use strict';
 
   global.CKEDITOR.plugins.add('cortex_media_insert', {
@@ -6,14 +6,14 @@
     init: function (editor) {
       editor.addCommand('insertMedia', {
         exec: function (editor) {
-          window.MODALS.featured.open();
+          window.MODALS.wysiwyg.open();
 
           global.media_select = {};
           global.media_select_defer = $.Deferred();
           global.media_select_defer.promise(global.media_select);
 
           global.media_select.done(function (media) {
-            window.MODALS.featured.close();
+            window.MODALS.wysiwyg.close();
 
             var mediaTag = editor.document.createElement('media');
             mediaTag.setAttribute('id', media.id);

--- a/app/assets/javascripts/cortex-field_types-core/application.js
+++ b/app/assets/javascripts/cortex-field_types-core/application.js
@@ -1,2 +1,4 @@
 //= require ckeditor/init
 //= require ../ckeditor/config
+
+//= require_tree ./cells

--- a/app/assets/javascripts/cortex-field_types-core/cells/content_item.js
+++ b/app/assets/javascripts/cortex-field_types-core/cells/content_item.js
@@ -1,0 +1,19 @@
+$('.media-select--featured').click(function (elem) {
+  var id = $(this).data().id;
+  var title = $(this).data().title;
+  var thumb_url = $(this).data().thumb;
+
+  $(".association_content_item_id").val(id);
+
+  $('.content-item-button__selection').remove();
+  $('.content-item-button').append(
+    '<div class="content-item-button__selection">' +
+    '<img src="' + thumb_url + '" height="50px">' +
+    '<div class="content-item-button__selection__text">' +
+    'Selected Media: ' +
+    title +
+    '</div></div>'
+  );
+
+  window.MODALS.featured.close();
+});

--- a/app/cells/plugins/core/asset/association.haml
+++ b/app/cells/plugins/core/asset/association.haml
@@ -1,0 +1,4 @@
+= render_associated_content_item_thumb
+.content-item-button__selection__text
+  Selected Media:
+  = associated_content_item_title

--- a/app/cells/plugins/core/asset_cell.rb
+++ b/app/cells/plugins/core/asset_cell.rb
@@ -3,8 +3,13 @@ module Plugins
     class AssetCell < Plugins::Core::Cell
       include ActionView::Helpers::NumberHelper
       include UtilityHelper
+      include Cells::AssociationHelper
 
       def input
+        render
+      end
+
+      def association
         render
       end
 
@@ -32,6 +37,14 @@ module Plugins
 
       def render_input
         @options[:form].file_field 'data[asset]'
+      end
+
+      def associated_content_item_thumb_url
+        data['asset']['style_urls']['mini']
+      end
+
+      def render_associated_content_item_thumb
+        image_tag(associated_content_item_thumb_url, height: '50px')
       end
     end
   end

--- a/app/cells/plugins/core/content_item/popup.haml
+++ b/app/cells/plugins/core/content_item/popup.haml
@@ -3,14 +3,17 @@
 
 = render_label
 %br
-%button.content_item_button.text-center.popup--open
-  .button_content
+%button.content-item-button.text-center.popup--open
+  .content-item-button__select.content-item-button__select--selected
     %i{ class: "material-icons icon" }
       cloud_upload
     %br
-    %span.content_item_button-text
-      Click to add a
+    %span.content-item-button__select__text
+      Click to select a
       = field.name
-      from the media library
+      from the Media library
+  - if associated_content_item && associated_primary_field_type_class == AssetFieldType
+    .content-item-button__selection
+      = render_association_cell
 %small
   Recommended size: 1452px x 530px with a live area of 930px x 530px

--- a/app/cells/plugins/core/content_item/popup.haml
+++ b/app/cells/plugins/core/content_item/popup.haml
@@ -3,7 +3,7 @@
 
 = render_label
 %br
-%button.content-item-button.text-center.popup--open
+%button.content-item-button.popup--open
   .content-item-button__select.content-item-button__select--selected
     %i{ class: "material-icons icon" }
       cloud_upload

--- a/app/cells/plugins/core/content_item_cell.rb
+++ b/app/cells/plugins/core/content_item_cell.rb
@@ -11,12 +11,47 @@ module Plugins
         data&.[]('content_item_id')
       end
 
+      def associated_content_item
+        ContentItem.find_by_id(value)
+      end
+
+      def associated_primary_field
+        associated_content_item.content_type.fields.find_by_name(field.metadata['field_name'])
+      end
+
+      def associated_primary_field_type_class
+        associated_primary_field.field_type_instance.class
+      end
+
+      def associated_primary_field_item
+        associated_content_item.field_items.find_by_field_id associated_primary_field
+      end
+
+      def associated_content_item_title
+        # Gross hack, this should rely on 'primary title field' config feature in future, and should use a scope
+        title_field_item = associated_content_item.field_items.find do |field_item|
+          field_item.field.name == 'Title'
+        end
+
+        title_field_item.data['text']
+      end
+
       def render_label
-        "Add #{field.name}"
+        "Select #{field.name}"
       end
 
       def render_content_item_id
-        @options[:form].hidden_field 'data[content_item_id]', value: value
+        @options[:form].hidden_field 'data[content_item_id]', value: value, class: 'association_content_item_id'
+      end
+
+      def render_association_cell
+        cell(Plugins::Core::AssetCell, associated_primary_field_item,
+             associated_content_item: associated_content_item,
+             associated_primary_field: associated_primary_field,
+             associated_primary_field_type_class: associated_primary_field_type_class,
+             associated_primary_field_item: associated_primary_field_item,
+             associated_content_item_title: associated_content_item_title)
+        .(:association)
       end
     end
   end

--- a/cortex-plugins-core.gemspec
+++ b/cortex-plugins-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "cells-haml", "~> 0.0.10"
   s.add_dependency "mimemagic", "~> 0.3.2"
   s.add_dependency "ckeditor", "= 4.2.0"
-  s.add_dependency "jsonb_accessor", "~> 1.0.0.beta.2"
+  s.add_dependency "jsonb_accessor", "~> 1.0.0.beta"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
This PR fully implements `ContentItemFieldType` selection. Its implementation is loosely based on https://github.com/cbdr/cortex/issues/423. Things to note:
* The Cell logic is the "good" implementation - it's almost entirely generic, sans a couple trivial hardcoded bits. Even though this neat generic implementation will never be used, we can follow along when we're creating the React implementation - pretend this is a "reference" implementation that we can study later on.
* The JS bits are the "bad" parts. They're mostly hardcoded, given our current infrastructure - the server knows too much, and the client knows too little. It works, however, and its implementation is irrelevant to the platform's success.