### PR TITLE
COR-537: Changed FieldType Validation To Use Field Instance

### DIFF
--- a/app/models/text_field_type.rb
+++ b/app/models/text_field_type.rb
@@ -36,8 +36,8 @@ class TextFieldType < FieldType
   end
 
   def text_unique
-    unless Field.find_by_name(field_info.name).field_items.jsonb_contains(:data, text: text).empty?
-      errors.add(:text, "#{field_info.name} Must be unique")
+    unless field.field_items.jsonb_contains(:data, text: text).empty?
+      errors.add(:text, "#{field.name} Must be unique")
     end
   end
 


### PR DESCRIPTION
@toastercup @ElliottAYoung  
Since **Field** name's are not globally unique, and since we are already passing the field instance I changed running validations using the field's name to using the actual field: 


**from:**
```ruby
unless Field.find_by_name(field_info.name).field_items.jsonb_contains(:data, text: text).empty?
```

**to:**
```ruby
unless field.field_items.jsonb_contains(:data, text: text).empty?		
```
