### PR TITLE
 FieldType Validation Bug Fix

### DIFF
--- a/app/models/text_field_type.rb
+++ b/app/models/text_field_type.rb
@@ -37,7 +37,7 @@ class TextFieldType < FieldType
 
   def text_unique
     unless field.field_items.jsonb_contains(:data, text: text).empty?
-      errors.add(:text, "#{field.name} Must be unique")
+      errors.add(:text, "#{field.name} Must be unique") if field_item.content_item_id == nil
     end
   end
 

--- a/app/models/text_field_type.rb
+++ b/app/models/text_field_type.rb
@@ -36,8 +36,7 @@ class TextFieldType < FieldType
   end
 
   def text_unique
-    return if metadata[:existing_data][:text] == text
-    unless field.field_items.jsonb_contains(:data, text: text).empty?
+    unless metadata[:existing_data][:text] == text || field.field_items.jsonb_contains(:data, text: text).empty?
       errors.add(:text, "#{field.name} Must be unique")
     end
   end

--- a/app/models/text_field_type.rb
+++ b/app/models/text_field_type.rb
@@ -36,8 +36,9 @@ class TextFieldType < FieldType
   end
 
   def text_unique
+    return if metadata[:existing_data][:text] == text
     unless field.field_items.jsonb_contains(:data, text: text).empty?
-      errors.add(:text, "#{field.name} Must be unique") if field_item.content_item_id == nil
+      errors.add(:text, "#{field.name} Must be unique")
     end
   end
 


### PR DESCRIPTION
I had to pass the `FieldItem` instance to `FieldType` to know whether or not a `ContentItem` is new or not. Alternatively i could have passed the `ContentItem` instance, or even an attribute like `record_update` could work as well. 

Here is the corresponding Cortex PR: [cortex/pull#430](https://github.com/cbdr/cortex/pull/430)