### PR TITLE
Implement CKEditor Widget System + Instant Media Insert

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -1,6 +1,7 @@
 CKEDITOR.plugins.addExternal( 'cortex_media_insert', '/assets/ckeditor/plugins/cortex_media_insert/' );
 
 CKEDITOR.editorConfig = function( config ) {
+  config.allowedContent = true;
   config.extraPlugins = 'cortex_media_insert';
 
 	config.toolbarGroups = [

--- a/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
+++ b/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
@@ -2,7 +2,26 @@
   'use strict';
 
   global.CKEDITOR.plugins.add('cortex_media_insert', {
+    requires: 'widget',
     init: function (editor) {
+      editor.widgets.add('media', {
+        template: '<media><img></media>',
+        data: function () {
+          if (this.data.id) {
+            var image_element = this.element.getFirst(),
+              alt_text = this.data.alt || this.data.title;
+
+            this.element.setAttribute('id', this.data.id);
+            image_element.setAttribute('src', this.data.image_source);
+            image_element.setAttribute('alt', alt_text);
+          }
+        },
+        requiredContent: 'media; img',
+        upcast: function (element) {
+          return element.name == 'media';
+        }
+      });
+
       editor.addCommand('insertMedia', {
         exec: function (editor) {
           window.MODALS.wysiwyg.open();
@@ -14,11 +33,14 @@
           global.media_select.done(function (media) {
             window.MODALS.wysiwyg.close();
 
-            var mediaTag = editor.document.createElement('media');
-            mediaTag.setAttribute('id', media.id);
-            mediaTag.setText(" " + media.title);
-
-            editor.insertElement(mediaTag);
+            editor.execCommand('media', {
+              startupData: {
+                id: media.id,
+                title: media.title,
+                image_source: media.src,
+                alt: media.alt
+              }
+            });
           });
         }
       });

--- a/lib/cortex/plugins/core/version.rb
+++ b/lib/cortex/plugins/core/version.rb
@@ -1,7 +1,7 @@
 module Cortex
   module Plugins
     module Core
-      VERSION = '0.7.2'
+      VERSION = '0.8.0'
     end
   end
 end


### PR DESCRIPTION
This PR, along with one in Cortex, rewrites the `insertMedia` plugin to use the CKEditor Widget system. This way, the image is not directly editable by a user - they need to go through the widget system or edit the `<media>` tag to alter what's produced in the `<img`> tag. Additionally, upon insertion, images and their alt text are now pulled through and immediately displayed.

Please see the CKEditor Widget tutorial for more details on how all this zaniness works: http://docs.ckeditor.com/#!/guide/widget_sdk_tutorial_2