### PR TITLE
Email in User Picker

### DIFF
--- a/app/cells/plugins/core/user_cell.rb
+++ b/app/cells/plugins/core/user_cell.rb
@@ -16,7 +16,7 @@ module Plugins
       end
 
       def user_data_for_select
-        @options[:user_data].map{ |user| [user.fullname, user.id] }
+        @options[:user_data].map{ |user| ["#{user.fullname} (#{user.email})", user.id] }
       end
     end
   end


### PR DESCRIPTION
Include email in `UserFieldType` picker, so content creators can discern between users with the same fullname