### PR TITLE
Add More Attributes to CKEditor Media Widget

### DIFF
--- a/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
+++ b/app/assets/javascripts/ckeditor/plugins/cortex_media_insert/plugin.js
@@ -7,14 +7,22 @@
       editor.widgets.add('media', {
         template: '<media><img></media>',
         data: function () {
-          if (this.data.id) {
-            var image_element = this.element.getFirst(),
-              alt_text = this.data.alt || this.data.title;
+          var image_element = this.element.getFirst(),
+            alt_text = this.data.alt || this.data.title,
+            width = this.data.width || this.element.getAttribute('width'),
+            height = this.data.height || this.element.getAttribute('height'),
+            style = this.data.style || this.element.getAttribute('style'),
+            className = this.data.class || this.element.getAttribute('class');
 
+          if (this.data.id) {
             this.element.setAttribute('id', this.data.id);
             image_element.setAttribute('src', this.data.image_source);
             image_element.setAttribute('alt', alt_text);
           }
+          if (width) image_element.setAttribute('width', width);
+          if (height) image_element.setAttribute('height', height);
+          if (style) image_element.setAttribute('style', style);
+          if (className) image_element.setAttribute('class', className);
         },
         requiredContent: 'media; img',
         upcast: function (element) {


### PR DESCRIPTION
* Add support for `width`, `height`, `style` and `class`
* Always rebuild these attributes on data init for CKEditor Media Widget