### PR TITLE
COR-625: Add support for blank values in Dropdowns

### DIFF
--- a/app/cells/plugins/core/checkbox_cell.rb
+++ b/app/cells/plugins/core/checkbox_cell.rb
@@ -25,7 +25,7 @@ module Plugins
 
       def display_lineage
         @options[:child].to_s + " " + @options[:node]["node"]["name"]
-      end
+      end 
     end
   end
 end

--- a/app/cells/plugins/core/tree_cell.rb
+++ b/app/cells/plugins/core/tree_cell.rb
@@ -21,8 +21,12 @@ module Plugins
 
       def metadata_values
         @options[:metadata]["data"]["tree_array"].map do |value|
-          [value["node"]["name"], value["id"]]
+          [display_label(value["node"]["name"]), value["id"]]
         end
+      end
+
+      def display_label(label)
+        label.blank? ? "N/A" : label
       end
     end
   end


### PR DESCRIPTION
Adds a check to see if the label / tree value is blank - If so it will render 'N/A', if not it will just render whatever the given value was.
This will allow Users to have blank values in dropdowns that appear as 'N/A', rather than simply a blank value