### PR TITLE
COR-626: Default User Select To Current User

### DIFF
--- a/app/cells/plugins/core/user_cell.rb
+++ b/app/cells/plugins/core/user_cell.rb
@@ -1,6 +1,8 @@
 module Plugins
   module Core
     class UserCell < Plugins::Core::Cell
+      include Devise::Controllers::Helpers
+
       def dropdown
         render
       end
@@ -8,7 +10,7 @@ module Plugins
       private
 
       def value
-        data&.[]('user_id') || @options[:default_value]
+        data&.[]('user_id') || @options[:default_value] || current_user.id
       end
 
       def render_select


### PR DESCRIPTION
Utilize Devise's `current_user` helper to default `UserField` dropdown to currently logged in user