### PR TITLE
Expose Seeder Errors

### DIFF
--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -13,7 +13,7 @@ namespace :cortex do
                                   creator_id: 1,
                                   contract_id: 1
                                 })
-        media.save
+        media.save!
 
         puts "Creating Fields..."
 
@@ -47,7 +47,7 @@ namespace :cortex do
         media.fields.new(name: 'Tags', field_type: 'tag_field_type')
         media.fields.new(name: 'Expiration Date', field_type: 'date_time_field_type')
         media.fields.new(name: 'Alt Tag', field_type: 'text_field_type')
-        media.save
+        media.save!
 
         puts "Creating Wizard Decorators..."
         wizard_hash = {
@@ -116,9 +116,9 @@ namespace :cortex do
         }
 
         media_wizard_decorator = Decorator.new(name: "Wizard", data: wizard_hash)
-        media_wizard_decorator.save
+        media_wizard_decorator.save!
 
-        ContentableDecorator.create({
+        ContentableDecorator.create!({
                                       decorator_id: media_wizard_decorator.id,
                                       contentable_id: media.id,
                                       contentable_type: 'ContentType'
@@ -199,9 +199,9 @@ namespace :cortex do
         }
 
         media_index_decorator = Decorator.new(name: "Index", data: index_hash)
-        media_index_decorator.save
+        media_index_decorator.save!
 
-        ContentableDecorator.create({
+        ContentableDecorator.create!({
                                       decorator_id: media_index_decorator.id,
                                       contentable_id: media.id,
                                       contentable_type: 'ContentType'


### PR DESCRIPTION
**Purpose:**
This is a small refactor of the seeder so that it throws exceptions for record saves. This should make it obvious when the process breaks (previously it would hum along merrily).

**JIRA:**
N/A

**Changes:**
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A
  
* Library changes
  * N/A

* Side effects
  * If you break the seeder, it'll get mad!

**Screenshots**
* Before
N/A

* After
N/A

**QA Links:**
N/A

**How to Verify These Changes**
* Specific pages to visit
  * N/A

* Steps to take
  * Please run the seeder and verify it still works: `bundle exec rake cortex:core:db:reseed`

* Responsive considerations
  * N/A

**Relevant PRs/Dependencies:**
Complementary `cortex` PR: https://github.com/cbdr/cortex/pull/457

**Additional Information**
N/A