### PR TITLE
COR 689: Switch Asset File Naming Structure

### DIFF
--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -76,7 +76,7 @@ class AssetFieldType < FieldType
   end
 
   def asset_title_slug
-    binding.pry
+    existing_data['asset_title_slug'] || ContentItemService.form_fields[@metadata[:naming_data]][:text].parameterize.underscore
   end
 
   def mapping_field_name
@@ -124,7 +124,7 @@ class AssetFieldType < FieldType
   end
 
   def style_urls
-    if existing_data.empty?
+    if @existing_data.empty?
       (metadata[:styles].map { |key, value| [key, asset.url(key)] }).to_h
     else
       existing_data.deep_symbolize_keys[:asset][:style_urls]
@@ -134,8 +134,8 @@ class AssetFieldType < FieldType
   def existing_metadata
     metadata.except!(:existing_data)
 
-    unless existing_data.empty?
-      metadata[:path].gsub!(":naming_data", existing_data['asset_title_slug']) if metadata[:path]
+    if @existing_data.empty?
+      metadata[:path].gsub!(":asset_title_slug", asset_title_slug) if metadata[:path]
     end
 
     metadata

--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -36,7 +36,7 @@ class AssetFieldType < FieldType
         'file_size': asset_file_size,
         'updated_at': asset_updated_at
       },
-      'asset_title_slug': asset_title_slug,
+      'media_title': media_title,
       'asset_field_type_id': id
     }
   end
@@ -75,8 +75,8 @@ class AssetFieldType < FieldType
     end
   end
 
-  def asset_title_slug
-    @existing_data['asset_title_slug'] || ContentItemService.form_fields[@metadata[:naming_data]][:text].parameterize.underscore
+  def media_title
+    @existing_data['media_title'] || ContentItemService.form_fields[@metadata[:naming_data][:title]][:text].parameterize.underscore
   end
 
   def mapping_field_name
@@ -133,7 +133,7 @@ class AssetFieldType < FieldType
 
   def existing_metadata
     metadata.except!(:existing_data)
-    metadata[:path].gsub!(":asset_title_slug", asset_title_slug) if metadata[:path]
+    metadata[:path].gsub!(":media_title", media_title) if metadata[:path]
     metadata
   end
 end

--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -36,6 +36,7 @@ class AssetFieldType < FieldType
         'file_size': asset_file_size,
         'updated_at': asset_updated_at
       },
+      'asset_title_slug': asset_title_slug,
       'asset_field_type_id': id
     }
   end
@@ -72,6 +73,10 @@ class AssetFieldType < FieldType
     validations[:allowed_extensions].collect do |allowed_content_type|
       MimeMagic.by_extension(allowed_content_type).type
     end
+  end
+
+  def asset_title_slug
+    binding.pry
   end
 
   def mapping_field_name
@@ -130,7 +135,7 @@ class AssetFieldType < FieldType
     metadata.except!(:existing_data)
 
     unless existing_data.empty?
-      metadata[:path].gsub!(":id", existing_data['asset_field_type_id']) if metadata[:path]
+      metadata[:path].gsub!(":naming_data", existing_data['asset_title_slug']) if metadata[:path]
     end
 
     metadata

--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -76,7 +76,7 @@ class AssetFieldType < FieldType
   end
 
   def asset_title_slug
-    existing_data['asset_title_slug'] || ContentItemService.form_fields[@metadata[:naming_data]][:text].parameterize.underscore
+    @existing_data['asset_title_slug'] || ContentItemService.form_fields[@metadata[:naming_data]][:text].parameterize.underscore
   end
 
   def mapping_field_name
@@ -127,17 +127,13 @@ class AssetFieldType < FieldType
     if @existing_data.empty?
       (metadata[:styles].map { |key, value| [key, asset.url(key)] }).to_h
     else
-      existing_data.deep_symbolize_keys[:asset][:style_urls]
+      @existing_data.deep_symbolize_keys[:asset][:style_urls]
     end
   end
 
   def existing_metadata
     metadata.except!(:existing_data)
-
-    if @existing_data.empty?
-      metadata[:path].gsub!(":asset_title_slug", asset_title_slug) if metadata[:path]
-    end
-
+    metadata[:path].gsub!(":asset_title_slug", asset_title_slug) if metadata[:path]
     metadata
   end
 end

--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -76,7 +76,7 @@ class AssetFieldType < FieldType
   end
 
   def media_title
-    @existing_data['media_title'] || ContentItemService.form_fields[@metadata[:naming_data][:title]][:text].parameterize.underscore
+    existing_data['media_title'] || ContentItemService.form_fields[@metadata[:naming_data][:title]][:text].parameterize.underscore
   end
 
   def mapping_field_name
@@ -124,10 +124,10 @@ class AssetFieldType < FieldType
   end
 
   def style_urls
-    if @existing_data.empty?
+    if existing_data.empty?
       (metadata[:styles].map { |key, value| [key, asset.url(key)] }).to_h
     else
-      @existing_data.deep_symbolize_keys[:asset][:style_urls]
+      existing_data.deep_symbolize_keys[:asset][:style_urls]
     end
   end
 

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -31,7 +31,9 @@ namespace :cortex do
                            },
                          metadata:
                            {
-                             naming_data: fieldTitle.id,
+                             naming_data: {
+                               title: fieldTitle.id
+                             },
                              styles: {
                                large: {geometry: '1800x1800>', format: :jpg},
                                medium: {geometry: '800x800>', format: :jpg},
@@ -42,7 +44,7 @@ namespace :cortex do
                              },
                              processors: [:thumbnail, :paperclip_optimizer],
                              preserve_files: true,
-                             path: ':class/:attachment/:asset_title_slug-:style.:extension',
+                             path: ':class/:attachment/:media_title-:style.:extension',
                              s3_headers: {'Cache-Control': 'public, max-age=315576000'}
                            })
         media.fields.new(name: 'Description', field_type: 'text_field_type', validations: {presence: true})

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -18,7 +18,11 @@ namespace :cortex do
         puts "Creating Fields..."
 
         allowed_asset_content_types = %w(txt css js pdf doc docx ppt pptx csv xls xlsx svg ico png jpg gif bmp)
+        media.fields.new(name: 'Title', field_type: 'text_field_type', validations: {presence: true, uniqueness: true})
         media.fields.new(name: 'Asset', field_type: 'asset_field_type',
+                         naming_data: {
+                           title: media.fields.find_by_name('Title').id
+                         },
                          validations:
                            {
                              presence: true,
@@ -39,10 +43,9 @@ namespace :cortex do
                              },
                              processors: [:thumbnail, :paperclip_optimizer],
                              preserve_files: true,
-                             path: ':class/:attachment/careerbuilder-:style-:id.:extension',
+                             path: ':class/:attachment/:naming_data-:style.:extension',
                              s3_headers: {'Cache-Control': 'public, max-age=315576000'}
                            })
-        media.fields.new(name: 'Title', field_type: 'text_field_type', validations: {presence: true})
         media.fields.new(name: 'Description', field_type: 'text_field_type', validations: {presence: true})
         media.fields.new(name: 'Tags', field_type: 'tag_field_type')
         media.fields.new(name: 'Expiration Date', field_type: 'date_time_field_type')

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -18,12 +18,9 @@ namespace :cortex do
         puts "Creating Fields..."
 
         allowed_asset_content_types = %w(txt css js pdf doc docx ppt pptx csv xls xlsx svg ico png jpg gif bmp)
-        media.fields.new(name: 'Title', field_type: 'text_field_type', validations: {presence: true, uniqueness: true})
+        fieldTitle = media.fields.new(name: 'Title', field_type: 'text_field_type', validations: {presence: true, uniqueness: true})
+        fieldTitle.save
         media.fields.new(name: 'Asset', field_type: 'asset_field_type',
-                         naming_data:
-                           {
-                             title: media.fields.find_by_name('Title').id
-                           },
                          validations:
                            {
                              presence: true,
@@ -34,6 +31,7 @@ namespace :cortex do
                            },
                          metadata:
                            {
+                             naming_data: fieldTitle.id,
                              styles: {
                                large: {geometry: '1800x1800>', format: :jpg},
                                medium: {geometry: '800x800>', format: :jpg},
@@ -44,13 +42,14 @@ namespace :cortex do
                              },
                              processors: [:thumbnail, :paperclip_optimizer],
                              preserve_files: true,
-                             path: ':class/:attachment/:naming_data-:style.:extension',
+                             path: ':class/:attachment/:asset_title_slug-:style.:extension',
                              s3_headers: {'Cache-Control': 'public, max-age=315576000'}
                            })
         media.fields.new(name: 'Description', field_type: 'text_field_type', validations: {presence: true})
         media.fields.new(name: 'Tags', field_type: 'tag_field_type')
         media.fields.new(name: 'Expiration Date', field_type: 'date_time_field_type')
         media.fields.new(name: 'Alt Tag', field_type: 'text_field_type')
+
         media.save!
 
         puts "Creating Wizard Decorators..."
@@ -65,7 +64,7 @@ namespace :cortex do
                   "grid_width": 12,
                   "elements": [
                     {
-                      "id": media.fields[0].id
+                      "id": media.fields.find_by_name('Asset').id
                     }
                   ]
                 }
@@ -80,23 +79,23 @@ namespace :cortex do
                   "grid_width": 6,
                   "elements": [
                     {
-                      "id": media.fields[1].id
+                      "id": media.fields.find_by_name('Title').id
                     },
                     {
-                      "id": media.fields[2].id,
+                      "id": media.fields.find_by_name('Description').id,
                       "render_method": "multiline_input",
                       "display": {
                          "rows": 3
                       }
                     },
                     {
-                      "id": media.fields[3].id
+                      "id": media.fields.find_by_name('Tags').id
                     },
                     {
-                      "id": media.fields[4].id
+                      "id": media.fields.find_by_name('Expiration Date').id
                     },
                     {
-                      "id": media.fields[5].id
+                      "id": media.fields.find_by_name('Alt Tag').id
                     }
                   ]
                 },
@@ -167,7 +166,7 @@ namespace :cortex do
                 "cells": [
                   {
                     "field": {
-                      "id": media.fields[1].id
+                      "id": media.fields.find_by_name('Title').id
                     },
                     "display": {
                       "classes": [
@@ -178,7 +177,7 @@ namespace :cortex do
                   },
                   {
                     "field": {
-                      "id": media.fields[2].id
+                      "id": media.fields.find_by_name('Description').id
                     }
                   }
                 ]
@@ -188,7 +187,7 @@ namespace :cortex do
                 "cells": [
                   {
                     "field": {
-                      "id": media.fields[3].id
+                      "id": media.fields.find_by_name('Tags').id
                     },
                     "display": {
                       "classes": [

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -20,9 +20,10 @@ namespace :cortex do
         allowed_asset_content_types = %w(txt css js pdf doc docx ppt pptx csv xls xlsx svg ico png jpg gif bmp)
         media.fields.new(name: 'Title', field_type: 'text_field_type', validations: {presence: true, uniqueness: true})
         media.fields.new(name: 'Asset', field_type: 'asset_field_type',
-                         naming_data: {
-                           title: media.fields.find_by_name('Title').id
-                         },
+                         naming_data:
+                           {
+                             title: media.fields.find_by_name('Title').id
+                           },
                          validations:
                            {
                              presence: true,


### PR DESCRIPTION
**Purpose:** @justin3thompson  has requested for V2 Cortex, we switch from using the `ContentItem`'s guid to using a parameterized version of the asset's title. 


**JIRA:**
[COR-689](https://cb-content-enablement.atlassian.net/browse/COR-689)

**Changes:**
* Changes to setup
  * must have [https://github.com/cbdr/cortex/pull/459](https://github.com/cbdr/cortex/pull/459) pulled or merged to access  `ContentItemService.form_fields`

* Architectural changes
 * in `media.rake` I have added the attribute `:naming_data` which is the field id of the asset's Title field.
 * switched out `:id` to `:asset_title_slug` in `media.rake`
 * Added `asset_title_slug` attribute to `AssetFieldType` data method
 * created new method `asset_title_slug` that returns a parameterized underscore slug using the Asset's title. 
 * Asset URL's now gsub  `:asset_title_slug` as apposed to `:id` 

* Migrations
  * Cortex must reseed: `bundle exec rake cortex:core:db:reseed`
  
* Library changes
  * Will probably need to bump up a new version

* Side effects
  * Assets can no longer share the same title since it would cause assets to be overwritten. 

**Screenshots**
* Before
 n/a

* After
n/a

**QA Links:**
n/a

**How to Verify These Changes**
* Specific pages to visit
  * n/a

* Steps to take
  * create a media content type
  * click edit to see the URL it should have a snake case version of the asset name. 
  * edit the title to make sure the asset url slug does not change

* Responsive considerations
  * n/a


**Relevant PRs/Dependencies:**
[cortex/pull/459](https://github.com/cbdr/cortex/pull/459)

**Additional Information**
n/a