### PR TITLE
COR-667: Media Assets Not Updating

### DIFF
--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -14,6 +14,7 @@ class AssetFieldType < FieldType
   validates :asset, attachment_presence: true, if: :validate_presence?
   validate :validate_asset_size, if: :validate_size?
   validate :validate_asset_content_type, if: :validate_content_type?
+  validate :asset_extension, if: :existing_data?
 
   def metadata=(metadata_hash)
     @metadata = metadata_hash.deep_symbolize_keys
@@ -79,6 +80,12 @@ class AssetFieldType < FieldType
     existing_data['media_title'] || ContentItemService.form_fields[@metadata[:naming_data][:title]][:text].parameterize.underscore
   end
 
+  def asset_extension
+    unless existing_data['asset']['content_type'] == asset_content_type
+     errors.add(:asset, "Asset must be the same type of: #{existing_data['asset']['content_type']}")
+    end
+  end
+
   def mapping_field_name
     "#{field_name.parameterize('_')}_asset_file_name"
   end
@@ -96,6 +103,10 @@ class AssetFieldType < FieldType
   end
 
   alias_method :valid_presence_validation?, :validate_presence?
+
+  def existing_data?
+    existing_data.any?
+  end
 
   def validate_size?
     begin


### PR DESCRIPTION
**Purpose:** Since the media title will be replacing id for asset urls most of the "not updating" issues have been resolved. But there was still a risk of someone updating an asset with a different extension meaning posts that use the asset will not update. 

I cover this in detail in a Cortex issue: [cortex/issues/456](https://github.com/cbdr/cortex/issues/456)

**JIRA:**
[COR-667](https://cb-content-enablement.atlassian.net/browse/COR-667)

**Changes:**
* Changes to setup
  * n/a
* Architectural changes
 * add a validation to check to see if the new asset matches the `content_type` of the previous asset

* Migrations
  * n/a
  
* Library changes
  * Will probably need to bump up a new version

* Side effects
  * Assets can no longer be switched from something like an image to an mp4

**Screenshots**
* Before
 n/a

* After
n/a

**QA Links:**
n/a

**How to Verify These Changes**
* Specific pages to visit
  * n/a

* Steps to take
  * create a media content type
  * try and create new content type, expect to get an error

* Responsive considerations
  * n/a


**Relevant PRs/Dependencies:**
n/a

**Additional Information**
 [cortex/issues/456](https://github.com/cbdr/cortex/issues/456)