### PR TITLE
COR-674: Decouple Labels from Fields

### DIFF
--- a/app/cells/plugins/core/asset/input.haml
+++ b/app/cells/plugins/core/asset/input.haml
@@ -5,8 +5,8 @@
 = render_max_asset_size
 %br
 = render_field_id
+- if @options[:tooltip]
+  %p
+    = render_tooltip
 = render_label
 = render_input
-- if @options[:tooltip]
-  %br
-    = render_tooltip

--- a/app/cells/plugins/core/asset/input.haml
+++ b/app/cells/plugins/core/asset/input.haml
@@ -7,3 +7,6 @@
 = render_field_id
 = render_label
 = render_input
+- if @options[:tooltip]
+  %br
+    = render_tooltip

--- a/app/cells/plugins/core/asset_cell.rb
+++ b/app/cells/plugins/core/asset_cell.rb
@@ -39,6 +39,10 @@ module Plugins
         @options[:form].file_field 'data[asset]'
       end
 
+      def render_tooltip
+        @options[:tooltip]
+      end
+
       def associated_content_item_thumb_url
         data['asset']['style_urls']['mini']
       end

--- a/app/cells/plugins/core/author/input.haml
+++ b/app/cells/plugins/core/author/input.haml
@@ -2,4 +2,5 @@
   = render_field_id
   = render_label
   = render_input
+  = render_tooltip unless @options[:tooltip].nil?
   = render_default_value

--- a/app/cells/plugins/core/author/input.haml
+++ b/app/cells/plugins/core/author/input.haml
@@ -1,4 +1,4 @@
-.mdl-textfield.mdl-js-textfield.authorfield
+.mdl-textfield.mdl-js-textfield.authorfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
   = render_input

--- a/app/cells/plugins/core/boolean/checkbox.haml
+++ b/app/cells/plugins/core/boolean/checkbox.haml
@@ -2,5 +2,6 @@
 %label.mdl-checkbox.mdl-js-checkbox.mdl-js-ripple-effect{ for: checkbox_id }
   = render_checkbox
   = render_checkbox_label
+  = render_tooltip unless @options[:tooltip].nil?
 
 %br

--- a/app/cells/plugins/core/boolean/switch.haml
+++ b/app/cells/plugins/core/boolean/switch.haml
@@ -1,3 +1,4 @@
 = render_field_id
 = render_label
+= render_tooltip unless @options[:tooltip].nil?
 = render_switch

--- a/app/cells/plugins/core/content_item/popup.haml
+++ b/app/cells/plugins/core/content_item/popup.haml
@@ -2,6 +2,7 @@
 = render_content_item_id
 
 = render_label
+= render_tooltip unless @options[:tooltip].nil?
 %br
 %button.content-item-button#featured-button__select
   .content-item-button__select.content-item-button__select--selected

--- a/app/cells/plugins/core/date_time/datepicker.haml
+++ b/app/cells/plugins/core/date_time/datepicker.haml
@@ -1,4 +1,4 @@
-.mdl-textfield.mdl-js-textfield
+.mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
   = render_datepicker

--- a/app/cells/plugins/core/date_time/datepicker.haml
+++ b/app/cells/plugins/core/date_time/datepicker.haml
@@ -1,4 +1,5 @@
 .mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
+  = render_tooltip unless @options[:tooltip].nil?
   = render_datepicker

--- a/app/cells/plugins/core/float/input.haml
+++ b/app/cells/plugins/core/float/input.haml
@@ -1,5 +1,5 @@
 .mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
+  = render_tooltip unless @options[:tooltip].nil?
   = render_input
-  

--- a/app/cells/plugins/core/integer/input.haml
+++ b/app/cells/plugins/core/integer/input.haml
@@ -1,4 +1,5 @@
 .mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
+  = render_tooltip unless @options[:tooltip].nil?
   = render_input

--- a/app/cells/plugins/core/integer/input.haml
+++ b/app/cells/plugins/core/integer/input.haml
@@ -1,5 +1,4 @@
-.mdl-textfield.mdl-js-textfield
+.mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
   = render_input
-  

--- a/app/cells/plugins/core/tag/tag_picker.haml
+++ b/app/cells/plugins/core/tag/tag_picker.haml
@@ -1,5 +1,6 @@
 = render_field_id
 = render_label
+= render_tooltip unless @options[:tooltip].nil?
 %br
 %span{class: 'cortex-bootstrap'}
   = render_tag_field

--- a/app/cells/plugins/core/text/input.haml
+++ b/app/cells/plugins/core/text/input.haml
@@ -1,4 +1,5 @@
 .mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
+  = render_tooltip unless @options[:tooltip].nil?
   = render_input

--- a/app/cells/plugins/core/text/input.haml
+++ b/app/cells/plugins/core/text/input.haml
@@ -1,5 +1,4 @@
-.mdl-textfield.mdl-js-textfield
+.mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_field_id
   = render_label
   = render_input
-  

--- a/app/cells/plugins/core/text/multiline_input.haml
+++ b/app/cells/plugins/core/text/multiline_input.haml
@@ -1,4 +1,5 @@
 .mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_label
+  = render_tooltip unless @options[:tooltip].nil?
   = render_field_id
   = render_multiline_input

--- a/app/cells/plugins/core/text/multiline_input.haml
+++ b/app/cells/plugins/core/text/multiline_input.haml
@@ -1,4 +1,4 @@
-.mdl-textfield.mdl-js-textfield
+.mdl-textfield.mdl-js-textfield.mdl-textfield--floating-label
   = render_label
   = render_field_id
   = render_multiline_input

--- a/app/cells/plugins/core/tooltip/show.haml
+++ b/app/cells/plugins/core/tooltip/show.haml
@@ -1,3 +1,3 @@
 .icon.material-icons.tooltip-icon{ :id => tooltip_id } help
-.mdl-tooltip{ "data-mdl-for" => tooltip_id }
+.mdl-tooltip.mdl-tooltip--large{ "data-mdl-for" => tooltip_id }
   = @options[:tooltip]

--- a/app/cells/plugins/core/tooltip/show.haml
+++ b/app/cells/plugins/core/tooltip/show.haml
@@ -1,0 +1,3 @@
+.icon.material-icons.tooltip-icon{ :id => tooltip_id } help
+.mdl-tooltip{ "data-mdl-for" => tooltip_id }
+  = @options[:tooltip]

--- a/app/cells/plugins/core/tooltip_cell.rb
+++ b/app/cells/plugins/core/tooltip_cell.rb
@@ -1,0 +1,15 @@
+module Plugins
+  module Core
+    class TooltipCell < Plugins::Core::Cell
+      def show
+        render
+      end
+
+      private
+
+      def tooltip_id
+        @options[:id].parameterize('_')
+      end
+    end
+  end
+end

--- a/app/cells/plugins/core/tree/checkboxes.haml
+++ b/app/cells/plugins/core/tree/checkboxes.haml
@@ -1,4 +1,5 @@
 = render_label
+= render_tooltip unless @options[:tooltip].nil?
 
 %p
   Please select 1-2 Categories.

--- a/app/cells/plugins/core/tree/dropdown.haml
+++ b/app/cells/plugins/core/tree/dropdown.haml
@@ -1,4 +1,5 @@
 = render_label
+= render_tooltip unless @options[:tooltip].nil?
 %br
 = render_field_id
 = render_select

--- a/app/cells/plugins/core/user/dropdown.haml
+++ b/app/cells/plugins/core/user/dropdown.haml
@@ -1,4 +1,5 @@
 = render_label
+= render_tooltip unless @options[:tooltip].nil?
 %br
 = render_field_id
 = render_select

--- a/lib/cortex/plugins/core/version.rb
+++ b/lib/cortex/plugins/core/version.rb
@@ -1,7 +1,7 @@
 module Cortex
   module Plugins
     module Core
-      VERSION = '0.11.0'
+      VERSION = '0.11.1'
     end
   end
 end

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -66,7 +66,8 @@ namespace :cortex do
                   "grid_width": 12,
                   "elements": [
                     {
-                      "id": media.fields.find_by_name('Asset').id
+                      "id": media.fields.find_by_name('Asset').id,
+                      "tooltip": "Recommended blog featured image size: 1452px x 530px with a live area of 930px x 530px"
                     }
                   ]
                 }


### PR DESCRIPTION
Updates the inputs for various Field Types to use MDL's floating label, so that the label of the field is not hidden when the field is clicked into. Additionally, builds a reusable, general tooltip cell that handles rendering out the tooltip in the form and conveying the given message from the Wizard Decorator.

Relevant PRs: 
* Cortex PR: https://github.com/cbdr/cortex/pull/470
* Asset Tooltip PR: #54 