### PR TITLE
COR-686: Add Recommendation Text to Media

### DIFF
--- a/app/cells/plugins/core/asset/input.haml
+++ b/app/cells/plugins/core/asset/input.haml
@@ -5,8 +5,8 @@
 = render_max_asset_size
 %br
 = render_field_id
+- if @options[:tooltip]
+  %p
+    = render_tooltip
 = render_label
 = render_input
-- if @options[:tooltip]
-  %br
-    = render_tooltip

--- a/app/cells/plugins/core/asset/input.haml
+++ b/app/cells/plugins/core/asset/input.haml
@@ -7,3 +7,6 @@
 = render_field_id
 = render_label
 = render_input
+- if @options[:tooltip]
+  %br
+    = render_tooltip

--- a/app/cells/plugins/core/asset_cell.rb
+++ b/app/cells/plugins/core/asset_cell.rb
@@ -39,6 +39,10 @@ module Plugins
         @options[:form].file_field 'data[asset]'
       end
 
+      def render_tooltip
+        @options[:tooltip]
+      end
+
       def associated_content_item_thumb_url
         data['asset']['style_urls']['mini']
       end

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -66,7 +66,8 @@ namespace :cortex do
                   "grid_width": 12,
                   "elements": [
                     {
-                      "id": media.fields.find_by_name('Asset').id
+                      "id": media.fields.find_by_name('Asset').id,
+                      "tooltip": "Recommended blog featured image size: 1452px x 530px with a live area of 930px x 530px"
                     }
                   ]
                 }


### PR DESCRIPTION
Reuses the tooltip field I just built to leave a message, passed by the Wizard Decorator, on the asset Field Type in a form.

To be merged before #53 

Image:
<img width="627" alt="screen shot 2017-04-05 at 10 44 32 am" src="https://cloud.githubusercontent.com/assets/8419757/24714031/e7ff20c2-19ec-11e7-8378-41412ccc43cd.png">
