### PR TITLE
COR-736: Error Message on New Fields

### DIFF
--- a/app/cells/plugins/core/text_cell.rb
+++ b/app/cells/plugins/core/text_cell.rb
@@ -42,15 +42,15 @@ module Plugins
       end
 
       def render_input
-        @options[:form].text_field 'data[text]', value: value, placeholder: @options[:placeholder], class: 'mdl-textfield__input', required: required?
+        @options[:form].text_field 'data[text]', value: value, placeholder: @options[:placeholder], class: 'mdl-textfield__input', data: { required: required? }
       end
 
       def render_wysiwyg
-        @options[:form].text_area 'data[text]', value: value, class: "#{input_classes} wysiwyg_ckeditor", style: input_styles, required: required?
+        @options[:form].text_area 'data[text]', value: value, class: "#{input_classes} wysiwyg_ckeditor", style: input_styles, data: { required: required? }
       end
 
       def render_multiline_input
-        @options[:form].text_area 'data[text]', value: value , placeholder: @options[:placeholder], rows: input_display&.[](:rows) , class: 'mdl-textfield__input', required: required?
+        @options[:form].text_area 'data[text]', value: value , placeholder: @options[:placeholder], rows: input_display&.[](:rows) , class: 'mdl-textfield__input', data: { required: required? }
       end
     end
   end


### PR DESCRIPTION
This PR simply rewrites the require attribute for text fields so that they no longer show as red on page load. Instead of passing `required: true` to these fields we now send `data-required: true`, which we make sense of on the Cortex Side.