### PR TITLE
COR-772: Upgrade ES to 5.4.0

### DIFF
--- a/app/cells/plugins/core/tooltip_cell.rb
+++ b/app/cells/plugins/core/tooltip_cell.rb
@@ -8,7 +8,7 @@ module Plugins
       private
 
       def tooltip_id
-        @options[:id].parameterize('_')
+        @options[:id].parameterize(separator: '_')
       end
     end
   end

--- a/app/models/asset_field_type.rb
+++ b/app/models/asset_field_type.rb
@@ -43,7 +43,7 @@ class AssetFieldType < FieldType
   end
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_asset_file_name"
+    "#{field_name.parameterize(separator: '_')}_asset_file_name"
   end
 
   def promote

--- a/app/models/author_field_type.rb
+++ b/app/models/author_field_type.rb
@@ -22,7 +22,7 @@ class AuthorFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_author"
+    "#{field_name.parameterize(separator: '_')}_author"
   end
 
   def author_name_present

--- a/app/models/author_field_type.rb
+++ b/app/models/author_field_type.rb
@@ -16,13 +16,13 @@ class AuthorFieldType < FieldType
   end
 
   def mapping
-    {author_name: mapping_field_name, type: :string, analyzer: :snowball}
+    { name: mapping_field_name, type: :string, analyzer: :snowball }
   end
 
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_author_name"
+    "#{field_name.parameterize('_')}_author"
   end
 
   def author_name_present

--- a/app/models/boolean_field_type.rb
+++ b/app/models/boolean_field_type.rb
@@ -18,6 +18,6 @@ class BooleanFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_boolean"
+    "#{field_name.parameterize(separator: '_')}_boolean"
   end
 end

--- a/app/models/content_item_field_type.rb
+++ b/app/models/content_item_field_type.rb
@@ -18,6 +18,6 @@ class ContentItemFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_content_item"
+    "#{field_name.parameterize(separator: '_')}_content_item"
   end
 end

--- a/app/models/date_time_field_type.rb
+++ b/app/models/date_time_field_type.rb
@@ -21,7 +21,7 @@ class DateTimeFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_date_time"
+    "#{field_name.parameterize(separator: '_')}_date_time"
   end
 
   def timestamp_is_valid?

--- a/app/models/float_field_type.rb
+++ b/app/models/float_field_type.rb
@@ -23,7 +23,7 @@ class FloatFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_float"
+    "#{field_name.parameterize(separator: '_')}_float"
   end
 
   def validate_key(key)

--- a/app/models/integer_field_type.rb
+++ b/app/models/integer_field_type.rb
@@ -23,7 +23,7 @@ class IntegerFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_integer"
+    "#{field_name.parameterize(separator: '_')}_integer"
   end
 
   def validate_key

--- a/app/models/tag_field_type.rb
+++ b/app/models/tag_field_type.rb
@@ -21,7 +21,7 @@ class TagFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_tag"
+    "#{field_name.parameterize(separator: '_')}_tag"
   end
 
   def validate_presence?

--- a/app/models/text_field_type.rb
+++ b/app/models/text_field_type.rb
@@ -23,7 +23,7 @@ class TextFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_text"
+    "#{field_name.parameterize(separator: '_')}_text"
   end
 
   def text_length

--- a/app/models/tree_field_type.rb
+++ b/app/models/tree_field_type.rb
@@ -32,7 +32,7 @@ class TreeFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_tree"
+    "#{field_name.parameterize(separator: '_')}_tree"
   end
 
   def minimum

--- a/app/models/user_field_type.rb
+++ b/app/models/user_field_type.rb
@@ -21,7 +21,7 @@ class UserFieldType < FieldType
   private
 
   def mapping_field_name
-    "#{field_name.parameterize('_')}_user"
+    "#{field_name.parameterize(separator: '_')}_user"
   end
 
   def valid_user_id?


### PR DESCRIPTION
This PR applies the necessary changes for ElasticSearch to be upgraded from 2.4.1 to 5.4.0. This is still entirely backwards compatible with 2.4.1 (so it shouldn't break in the meantime), but without the moving to 5.4.0 is entirely impossible.

Changes:
* Fixes the `name` key for the author field type mapping
* Fixes and updates all `parameterize` methods to use the new syntax to avoid deprecation warnings coming out of the proverbial wazoo