### PR TITLE
CE-154: Tenancy

### DIFF
--- a/cortex-plugins-core.gemspec
+++ b/cortex-plugins-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.md", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4"
-  s.add_dependency "react_on_rails", "~> 6"
+  s.add_dependency "react_on_rails", "~> 8"
   s.add_dependency "cells", "~> 4.1"
   s.add_dependency "cells-rails", "~> 0.0"
   s.add_dependency "cells-haml", "~> 0.0"

--- a/lib/cortex/plugins/core/version.rb
+++ b/lib/cortex/plugins/core/version.rb
@@ -1,7 +1,7 @@
 module Cortex
   module Plugins
     module Core
-      VERSION = '1.0.0'
+      VERSION = '1.1.0'
     end
   end
 end

--- a/lib/tasks/cortex/core/media.rake
+++ b/lib/tasks/cortex/core/media.rake
@@ -5,13 +5,16 @@ namespace :cortex do
     namespace :media do
       desc 'Seed Cortex Media ContentType and Fields'
       task seed: :environment do
+        example_tenant = Tenant.find_by_name('Example')
+
         puts "Creating Media ContentType..."
         media = ContentType.new({
                                   name: "Media",
                                   description: "Media for Cortex",
                                   icon: "collections",
-                                  creator_id: 1,
-                                  contract_id: 1
+                                  tenant: example_tenant,
+                                  creator: User.first,
+                                  contract: Contract.first # TODO: This is obviously bad. This whole file is bad.
                                 })
         media.save!
 
@@ -158,13 +161,14 @@ namespace :cortex do
           ]
         }
 
-        media_wizard_decorator = Decorator.new(name: "Wizard", data: wizard_hash)
+        media_wizard_decorator = Decorator.new(name: "Wizard", data: wizard_hash, tenant: example_tenant)
         media_wizard_decorator.save!
 
         ContentableDecorator.create!({
                                       decorator_id: media_wizard_decorator.id,
                                       contentable_id: media.id,
-                                      contentable_type: 'ContentType'
+                                      contentable_type: 'ContentType',
+                                      tenant: example_tenant
                                     })
 
         puts "Creating Index Decorators..."
@@ -241,13 +245,14 @@ namespace :cortex do
             ]
         }
 
-        media_index_decorator = Decorator.new(name: "Index", data: index_hash)
+        media_index_decorator = Decorator.new(name: "Index", data: index_hash, tenant: example_tenant)
         media_index_decorator.save!
 
         ContentableDecorator.create!({
                                       decorator_id: media_index_decorator.id,
                                       contentable_id: media.id,
-                                      contentable_type: 'ContentType'
+                                      contentable_type: 'ContentType',
+                                      tenant: example_tenant
                                     })
       end
     end


### PR DESCRIPTION
## `cortex-plugins-core` Purpose:
* Seeds have been adjusted to apply example tenant to created `ContentTypes`/etc
* `ReactOnRails` upgraded to match version in `cortex`. Note that a true upgrade to RoR8 may require more work - there's a story in the backlog to account for this: https://careerbuilder.atlassian.net/browse/CE-172

## `cortex` Purpose:
* Implements tenancy across application. Some models (`ContentType`, `ContentItem`) belong directly to a `Tenant`, while others have implied association via their related records (`Field`, `FieldItem`, etc).
* Users can now belong to multiple tenants and toggle between them.
* The concept of `Organizations` has been implemented. When switched to a sub-tenant (at any depth), Cortex will collate all `ContentTypes` from parent `Tenants`. In the future, this will be expanded to check for uniqueness across an entire `Organization`.
* `ContentItems` are now saved into the `active_tenant`. This needs improvement in the future - a user could switch their `active_tenant` in another window which would affect the record save. When we rebuild the Wizard form, we should have it send up the desired `Tenant` to save the `ContentItem` in, and perform authorization checks accordingly.
* Massive refactor/pruning to all of our (ancient) migrations. These were built without modern best practices, for older versions of Rails, without foreign key constraints, and without optimal index configuration. No longer! Please review `db/schema.rb`, as all Beta Cortex models have changed a good bit.
* Further split from Legacy. *All* legacy-related logic was removed - models, API infrastructure, Doorkeeper, etc. These pieces can be added back in on an as-needed basis.
* `ActsAsParanoid` is now assumed for all application models. As such, it's been added to the base `ApplicationRecord` abstract class.
* In `ContentItemsController`, we now only rescue from `RecordInvalid`, not `StandardError`, so that more catastrophic errors are logged
* Small tweaks to ElasticSearch index rebuild
* Rebuilds and splits out `ContentItem` dynamic convenience methods. We now ensure they're registered as instance methods by Ruby. It will no longer respond to everything with an attempt to return `FieldItem` data - instead, it checks existence first, otherwise it responds with `method_missing`
* Rails has been upgraded from 5.0 to 5.1. However, there are still many changes that need to take place as part of this upgrade, which will be accounted for in https://careerbuilder.atlassian.net/browse/CE-173. This was necessary for now so we could build 5.1 ActiveRecord migrations.
* For almost every table in the database, we are now using UUID PKs
* Lots of refactors!

## JIRA:
https://careerbuilder.atlassian.net/browse/CE-154

## Steps to Take On Prod
This will require a complete rebuild of Production - hence the massive overhauling of our migrations.

## Changes:
* Changes to setup
  * You bet!

* Architectural changes
  * Aye!

* Migrations
  * Heavens, yes!

* Library changes
  * `cortex-plugins-core` will need a minor version bump

* Side effects
  * N/A

## Screenshots
* Before
N/A

* After
N/A

## QA Links:
http://web.cortex-2.development.c66.me/

## How to Verify These Changes
* Specific pages to visit
  * N/A

* Steps to take
  * Login as initial user (`admin@cortexcms.org`)
  * Switch tenants using @MKwenhua's tenant switcher. Ensure interface is updated with the correct `ContentType` menuitems on the Sidebar for each tenant
  * The 'Example' tenant contains Employer's `ContentTypes`. Its sub-tenant ('Bogus'), then, should also display these `ContentTypes` as menuitems, as all sub-tenants have access to `ContentTypes`/`Contracts`/`Decorators` from parent tenants.
* Create a `ContentItem` in a tenant and sub-tenant. Ensure that the `ContentItem` is only visible within the tenant it belongs to, and that saving/updating works as expected.
* Ensure Media selection works as expected and is scoped to the `active_tenant`.

* Responsive considerations
  * N/A

## Relevant PRs/Dependencies:
https://github.com/cbdr/cortex/pull/527

## Additional Information
N/A