### PR TITLE
CE-173: Rails 5.1 Upgrade

### DIFF
--- a/cortex-plugins-core.gemspec
+++ b/cortex-plugins-core.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.md", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 4"
+  s.add_dependency "rails", ">= 5"
   s.add_dependency "react_on_rails", "~> 8"
   s.add_dependency "cells", "~> 4.1"
   s.add_dependency "cells-rails", "~> 0.0"
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
 
   # AssetFieldType
   s.add_dependency "shrine", "~> 2.7"
+  s.add_dependency "aws-sdk-s3", "~> 1.5"
   s.add_dependency "mimemagic", "~> 0.3"
   s.add_dependency "image_processing", "~> 0.4"
   s.add_dependency "mini_magick", "~> 4.8"

--- a/lib/cortex/plugins/core/version.rb
+++ b/lib/cortex/plugins/core/version.rb
@@ -1,7 +1,7 @@
 module Cortex
   module Plugins
     module Core
-      VERSION = '1.1.1'
+      VERSION = '1.2.0'
     end
   end
 end


### PR DESCRIPTION
## `cortex-plugins-core` Purpose:
* Specifies `5.x` as Rails target version
* Specifies `aws-sdk` as explicit dependency (removing it from `cortex`, which does not need it), utilizes new split-out `aws-sdk-s3` gem

## `cortex` Purpose:
This PR accomplishes the following:
* Finalizes upgrade from Rails `5.0` -> `5.1` (which was partially complete)
* Ports over all Rails 5 config changes/improvements, comments, binstubs, etc
* Upgrades Ruby to `v2.4.2`
* Removes Bower, replaces with Yarn; moves all client-side dependencies to Yarn
* New Sprockets `4.x` config
* Improves sourcecode change detection/auto-reload
* Upgrades Gemfile
* Upgrades C66 server dependencies
* Updates documentation

## JIRA:
https://careerbuilder.atlassian.net/browse/CE-173

## Steps to Take On Prod
N/A

## Changes:
* Changes to setup
  * N/A

* Architectural changes
  * N/A

* Migrations
  * N/A

* Library changes
  * `cortex-plugins-core` upgrade required

* Side effects
  * N/A

## Screenshots
* Before
N/A

* After
N/A

## QA Links:
http://web.cortex-2.development.c66.me/

## How to Verify These Changes
* Specific pages to visit
  * All

* Steps to take
  * Login
  * Ensure tenant switcher works
  * Ensure Blog `ContentItems` can be created and updated

* Responsive considerations
  * N/A

## Relevant PRs/Dependencies:
https://github.com/cbdr/cortex/pull/530

## Additional Information
N/A